### PR TITLE
Support tokenizer decode in addition to vocab dict

### DIFF
--- a/sae_vis/data_storing_fns.py
+++ b/sae_vis/data_storing_fns.py
@@ -1,4 +1,5 @@
 import numpy as np
+from transformers.tokenization_utils_fast import PreTrainedTokenizerFast
 from typing import List
 import torch
 from torch import Tensor
@@ -217,7 +218,7 @@ class SequenceData:
     
     def get_html(
         self,
-        vocab_dict: Dict[int, str],
+        vocab_dict: Union[Dict[int, str], PreTrainedTokenizerFast],
         hovertext: bool = True,
         bold_idx: Optional[int] = None,
         overflow_x: Literal["break", None] = None,
@@ -260,7 +261,7 @@ class SequenceGroupData:
     
     def get_html(
         self,
-        vocab_dict: Dict[int, str],
+        vocab_dict: Union[Dict[int, str], PreTrainedTokenizerFast],
         group_size: Optional[int] = None,
         hovertext: bool = True,
         overflow_x: Literal["scroll", "hidden"] = "scroll",
@@ -319,7 +320,7 @@ class SequenceMultiGroupData:
 
     def get_html(
         self,
-        vocab_dict: Dict[int, str],
+        vocab_dict: Union[Dict[int, str], PreTrainedTokenizerFast],
         hovertext: bool = True
     ) -> str:
         '''
@@ -431,7 +432,7 @@ class MiddlePlotsData:
 
     def get_html(
         self,
-        vocab_dict: Dict[int, str],
+        vocab_dict: Union[Dict[int, str], PreTrainedTokenizerFast],
         grid_item: bool = True,
         compact: bool = False,
         histogram_line_idx: Optional[int] = None,
@@ -531,7 +532,7 @@ class PromptData:
     def get_html(
         self,
         title: str,
-        vocab_dict: Dict[int, str],
+        vocab_dict: Union[Dict[int, str], PreTrainedTokenizerFast],
         hovertext: bool = True,
         bold_idx: Optional[int] = None,
         width: Optional[int] = 420,
@@ -589,7 +590,7 @@ class MultiPromptData:
         self,
         seq_pos: int,
         str_score: Literal["act_size", "act_quantile", "loss_effect"],
-        vocab_dict: Dict[int, str],
+        vocab_dict: Union[Dict[int, str], PreTrainedTokenizerFast],
         width: Optional[int] = 420,
     ) -> str:
         

--- a/sae_vis/html_fns.py
+++ b/sae_vis/html_fns.py
@@ -1,5 +1,6 @@
 from matplotlib import colors
 import numpy as np
+from transformers.tokenization_utils_fast import PreTrainedTokenizerFast
 from typing import List, Optional, Tuple, Literal
 from pathlib import Path
 import re
@@ -59,7 +60,7 @@ BG_COLOR_MAP = colors.LinearSegmentedColormap.from_list("bg_color_map", ["white"
 
 
 def generate_tok_html(
-    vocab_dict: dict,
+    vocab_dict: Union[Dict[int, str], PreTrainedTokenizerFast],
     
     this_token: str,
     underline_color: str,
@@ -140,7 +141,7 @@ def generate_tok_html(
 
 
 def generate_seq_html(
-    vocab_dict: dict,
+    vocab_dict: Union[Dict[int, str], PreTrainedTokenizerFast],
     token_ids: List[str],
     feat_acts: List[float],
     contribution_to_loss: List[float],

--- a/sae_vis/utils_fns.py
+++ b/sae_vis/utils_fns.py
@@ -8,8 +8,7 @@ from torch import Tensor
 import numpy as np
 from transformers.tokenization_utils_fast import PreTrainedTokenizerFast
 from tqdm import tqdm
-from transformers import AutoTokenizer
-
+from transformers import GPT2TokenizerFast, GPTNeoXTokenizerFast, AutoTokenizer
 from transformer_lens import utils
 
 
@@ -157,16 +156,16 @@ def to_str_tokens(vocab_dict: Dict[int, str], tokens: Union[int, torch.Tensor]):
     them in the same shape as the original tensor (i.e. nested lists).
     '''
     if isinstance(tokens, int):
-        if isinstance(vocab_dict, AutoTokenizer):
-            return vocab_dict.decode(tokens)
-        else:
+        if isinstance(vocab_dict, dict):
             return vocab_dict[tokens]
+        else:
+            return vocab_dict.decode(tokens)
 
     # Get flattened list of tokens
-    if isinstance(vocab_dict, AutoTokenizer):
-        str_tokens = [vocab_dict.decode(t) for t in tokens.flatten().tolist()]
-    else:
+    if isinstance(vocab_dict, dict):
         str_tokens = [vocab_dict[t] for t in tokens.flatten().tolist()]
+    else:
+        str_tokens = [vocab_dict.decode(t) for t in tokens.flatten().tolist()]
 
     # Reshape
     return np.reshape(str_tokens, tokens.shape).tolist()

--- a/sae_vis/utils_fns.py
+++ b/sae_vis/utils_fns.py
@@ -8,6 +8,7 @@ from torch import Tensor
 import numpy as np
 from transformers.tokenization_utils_fast import PreTrainedTokenizerFast
 from tqdm import tqdm
+from transformers import AutoTokenizer
 
 from transformer_lens import utils
 
@@ -156,10 +157,16 @@ def to_str_tokens(vocab_dict: Dict[int, str], tokens: Union[int, torch.Tensor]):
     them in the same shape as the original tensor (i.e. nested lists).
     '''
     if isinstance(tokens, int):
-        return vocab_dict[tokens]
+        if isinstance(vocab_dict, AutoTokenizer):
+            return vocab_dict.decode(tokens)
+        else:
+            return vocab_dict[tokens]
 
     # Get flattened list of tokens
-    str_tokens = [vocab_dict[t] for t in tokens.flatten().tolist()]
+    if isinstance(vocab_dict, AutoTokenizer):
+        str_tokens = [vocab_dict.decode(t) for t in tokens.flatten().tolist()]
+    else:
+        str_tokens = [vocab_dict[t] for t in tokens.flatten().tolist()]
 
     # Reshape
     return np.reshape(str_tokens, tokens.shape).tolist()

--- a/sae_vis/utils_fns.py
+++ b/sae_vis/utils_fns.py
@@ -8,7 +8,6 @@ from torch import Tensor
 import numpy as np
 from transformers.tokenization_utils_fast import PreTrainedTokenizerFast
 from tqdm import tqdm
-from transformers import GPT2TokenizerFast, GPTNeoXTokenizerFast, AutoTokenizer
 from transformer_lens import utils
 
 
@@ -126,7 +125,7 @@ def create_vocab_dict(tokenizer: PreTrainedTokenizerFast) -> Dict[int, str]:
     '''
     Creates a vocab dict by replacing all the annoying special tokens with their HTML representations.
     '''
-    vocab_dict: Dict[str, int] = tokenizer.vocab
+    vocab_dict: Dict[int, str] = tokenizer.vocab
     vocab_dict = {v: process_str_tok(k) for k, v in vocab_dict.items()}
     return vocab_dict
 
@@ -150,7 +149,7 @@ def process_str_tok(str_tok: str) -> str:
 
 
 
-def to_str_tokens(vocab_dict: Dict[int, str], tokens: Union[int, torch.Tensor]):
+def to_str_tokens(vocab_dict: Union[Dict[int, str], PreTrainedTokenizerFast], tokens: Union[int, torch.Tensor]):
     '''
     Helper function which converts tokens to their string representations, but (if tokens is a tensor) keeps
     them in the same shape as the original tensor (i.e. nested lists).


### PR DESCRIPTION
`tokenizer.vocab` / `tokenizer.get_vocab()` behave differently to `tokenizer.decode()` in a couple of annoying ways. This is notable with some unicode characters such as fancy quotes or Cyrillic characters:

![image](https://github.com/callummcdougall/sae_vis/assets/148209923/e9d4f55c-b513-4333-93ff-aad523f0ab18)
(this also happens if you call `tokenizer.decode()` on individual integers)

Thus it can be nice to use `tokenizer.decode()` for the visualization.

In my own scripts I call `FeatureData()` directly, so I made the following modification that allows it to take a tokenizer alternative to a dict. Maybe you can use this to test if using the tokenizer directly also works for the general usecase, and adopt something like this?