### PR TITLE
fixing bug if hook_point == hook_point_resid_final

### DIFF
--- a/sae_vis/model_fns.py
+++ b/sae_vis/model_fns.py
@@ -185,7 +185,10 @@ class TransformerLensWrapper(nn.Module):
 
         # The hook functions work by storing data in model's hook context, so we pop them back out
         activation: Tensor = self.model.hook_dict[self.hook_point].ctx.pop("activation")
-        residual: Tensor = self.model.hook_dict[self.hook_point_resid_final].ctx.pop("activation")
+        if self.hook_point_resid_final == self.hook_point:
+            residual: Tensor = activation
+        else:
+            residual: Tensor = self.model.hook_dict[self.hook_point_resid_final].ctx.pop("activation")
 
         if return_logits:
             return output, residual, activation


### PR DESCRIPTION
If the SAE `hook_point` is the same as the `hook_point_resid_final`, an error is thrown since the code tries to pop the same value from the same dict twice. This PR adds a check to see if `hook_point` is the same as `hook_point_resid_final` and if so, just re-use the same value rather than trying to pop the value twice from ctx.