### PR TITLE
fixing repo URL in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     author = 'Callum McDougall',
     author_email = 'cal.s.mcdougall@gmail.com',
     description = "Open-source SAE visualizer, based on Anthropic's published visualizer.",
-    url = 'https://github.com/callummcdougall/sae_visualizer',
+    url = 'https://github.com/callummcdougall/sae_vis',
     classifiers = [
         'Programming Language :: Python :: 3',
         'Operating System :: OS Independent',


### PR DESCRIPTION
This PR fixes the URL link in `setup.py` to point to this repo, instead of https://github.com/callummcdougall/sae_visualizer (currently clicking on the "homepage" link on https://pypi.org/project/sae-vis/ links to sae_visualizer).

What is https://github.com/callummcdougall/sae_visualizer? Is that repo deprecated? If so, it would probably be helpful to archive that repo and put a note in the README to direct users to this repo instead.