### PR TITLE
Update and add some HTML_ANOMALIES

### DIFF
--- a/sae_vis/utils_fns.py
+++ b/sae_vis/utils_fns.py
@@ -193,9 +193,15 @@ HTML_CHARS = {
     "}": "&#125;",
 }
 HTML_ANOMALIES = {
-    "âĢĶ": "&ndash;",
+    "âĢĶ": "&mdash;",
+    "âĢĵ": "&ndash;",
     "âĢĻ": "&rsquo;",
     "âĢĭ": "&#8203;",
+    "âĢľ": "&ldquo;",
+    "âĢĿ": "&rdquo;",
+    "âĢĺ": "&lsquo;",
+    "âĢĻ": "&rsquo;",
+    # "âĢĭ": " ", # TODO: this is actually zero width space character. what's the best way to represent it?
     "Ġ": "&nbsp;",
     "Ċ": "&bsol;n",
     "ĉ": "&bsol;t",


### PR DESCRIPTION
- MODIFICATION: From my limited testing it seems that `âĢĶ` is `&mdash;` not `&ndash;`
- NEW: Added a few other anomalies
- LATER: There is a "zero width space character" (`âĢĭ`) that's commented out for now, since it's unclear how to appropriately represent them

weird coincidence that many of these anomalies look like the characters "agi" 🙂