### PR TITLE
Update setup.py with eindex dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     install_requires = [
         'torch',
         'einops',
+        'eindex-callum @ git+https://github.com/callummcdougall/eindex.git',
         'datasets',
         'dataclasses-json',
         'jaxtyping',

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,8 @@ setup(
         'torch',
         'einops',
         'eindex-callum @ git+https://github.com/callummcdougall/eindex.git',
+        'rich',
+        'transformer_lens',
         'datasets',
         'dataclasses-json',
         'jaxtyping',


### PR DESCRIPTION
Without this, installing the package will give you errors when e.g. you do `from sae_vis.data_fetching_fns import get_feature_data`.

Noticed this while working through [the SAELens tutorial](https://github.com/jbloomAus/SAELens/blob/main/tutorials/evaluating_your_sae.ipynb) , tested by installing with this change in a fresh env, confirming the import now works. Apologies for the bonus newline at the end, I can't work out how to exorcise it.

(Could consider pinning to a specific commit but I assume that's too rigid).

Thanks for your work, I'm really enjoying it!