### PR TITLE
Demo notebook errors under "Multi-layer models" vis

### DIFF
--- a/demo.ipynb
+++ b/demo.ipynb
@@ -48,7 +48,7 @@
         "try:\n",
         "    import google.colab # type: ignore\n",
         "    COLAB = True\n",
-        "    !git clone https://github.com/jbloomAus/mats_sae_training.git\n",
+        "    !git clone -b latest_eng_updates_feb_24 https://github.com/jbloomAus/mats_sae_training.git\n",
         "    %pip install transformer_lens\n",
         "    %pip install git+https://github.com/callummcdougall/eindex.git\n",
         "    %pip install sae-vis\n",


### PR DESCRIPTION
`Demo.ipynb` step `Feature-centric vis: multi-layer models` has two code blocks, both of which are failing. This pull request  (temporarily) fixes the issue in the first code block, but does not resolve the issue in the second code block.

The first block fails at `obj = torch.load(path, map_location="cpu")` with `sae_training` not found. The commit in this PR pins an older commit of `mats_sae_training` which fixes it.

However, the second code block is now failing. See [this notebook and scroll down to Feature-centric vis: multi-layer models](https://colab.research.google.com/drive/1rOn4r8xjz03fmfrNW2CSnnADkCmvw9m8?usp=sharing) for the error: `RuntimeError: selected index k out of range` for line:
```
sae_vis_data_gpt = SaeVisData.create(
    encoder = gpt2_sae,
    model = gpt2,
    tokens = all_tokens, # type: ignore
    cfg = feature_vis_config_gpt,
)
```

This is an incomplete PR, better fix is to make the notebook compatible with the new mats_sae_training (now SAELens).