### PR TITLE
FIX: SAELens new format has "scaling_factor" key, which causes assert to fail

### DIFF
--- a/sae_vis/data_storing_fns.py
+++ b/sae_vis/data_storing_fns.py
@@ -1016,8 +1016,10 @@ class SaeVisData:
 
         # If encoder isn't an AutoEncoder, we wrap it in one
         if not isinstance(encoder, AutoEncoder):
-            assert (
-                set(encoder.state_dict().keys()).issuperset({"W_enc", "W_dec", "b_enc", "b_dec"})
+            assert set(
+                encoder.state_dict().keys()
+            ).issuperset(
+                {"W_enc", "W_dec", "b_enc", "b_dec"}
             ), "If encoder isn't an AutoEncoder, it should have weights 'W_enc', 'W_dec', 'b_enc', 'b_dec'"
             d_in, d_hidden = encoder.W_enc.shape
             device = encoder.W_enc.device

--- a/sae_vis/data_storing_fns.py
+++ b/sae_vis/data_storing_fns.py
@@ -1014,13 +1014,13 @@ class SaeVisData:
         # If encoder isn't an AutoEncoder, we wrap it in one
         if not isinstance(encoder, AutoEncoder):
             assert (
-                set(encoder.state_dict().keys()) == {"W_enc", "W_dec", "b_enc", "b_dec"}
+                set(encoder.state_dict().keys()).issuperset({"W_enc", "W_dec", "b_enc", "b_dec"})
             ), "If encoder isn't an AutoEncoder, it should have weights 'W_enc', 'W_dec', 'b_enc', 'b_dec'"
             d_in, d_hidden = encoder.W_enc.shape
             device = encoder.W_enc.device
             encoder_cfg = AutoEncoderConfig(d_in=d_in, d_hidden=d_hidden)
             encoder_wrapper = AutoEncoder(encoder_cfg).to(device)
-            encoder_wrapper.load_state_dict(encoder.state_dict())
+            encoder_wrapper.load_state_dict(encoder.state_dict(), strict=False)
         else:
             encoder_wrapper = encoder
 


### PR DESCRIPTION
Issue: Error when loading the new SAELens SAE format into sae_vis because the new format has key `scaling_factor` and sae_vis requires an exact match with no extra keys.
```
  File "/Users/[username]/Documents/Projects/SAELens/.venv/lib/python3.11/site-packages/sae_vis/data_storing_fns.py", line 1019, in create
    set(encoder.state_dict().keys()) == {"W_enc", "W_dec", "b_enc", "b_dec"}
AssertionError: If encoder isn't an AutoEncoder, it should have weights 'W_enc', 'W_dec', 'b_enc', 'b_dec'
```

Fix: Allow a loaded SAE to have keys that are a superset of the expected keys, instead of an exact match.
