### PR TITLE
chore: setting up semantic-release for auto-deploy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,3 +22,36 @@ jobs:
         run: poetry run ruff format --check
       - name: check types
         run: poetry run pyright
+      - name: build
+        run: poetry build
+
+  release:
+    needs: build
+    permissions:
+      contents: write
+      id-token: write
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'chore(release):')
+    runs-on: ubuntu-latest
+    concurrency: release
+    environment:
+      name: pypi
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Semantic Release
+        id: release
+        uses: python-semantic-release/python-semantic-release@v8.0.7
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        if: steps.release.outputs.released == 'true'
+      - name: Publish package distributions to GitHub Releases
+        uses: python-semantic-release/upload-to-gh-release@main
+        if: steps.release.outputs.released == 'true'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,3 +60,11 @@ reportPrivateUsage = "none"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.semantic_release]
+version_variables = [
+    "sae_vis/__init__.py:__version__",
+    "pyproject.toml:version",
+]
+branch = "main"
+build_command = "pip install poetry && poetry build"

--- a/sae_vis/__init__.py
+++ b/sae_vis/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1"
+__version__ = "0.2.17"
 
 from .data_fetching_fns import *
 from .data_storing_fns import *


### PR DESCRIPTION
This PR sets up [semantic release](https://semantic-release.gitbook.io/semantic-release) to automatically deploy builds to PyPI in a github action based on commit message. This means that the commit message to main will determine how the version is bumped in a deploy, or whether a deploy happens at all. Semantic release will also automatically generate and update a changelog for the project. For example, the following commit messages will bump the version number as follows:

`chore: updating docs` no version bump
`fix: the main class no longer errors on osx` patch version bump (1.2.3 -> 1.2.4)
`feat: added a new function` minor version bump (1.2.3 -> 1.3.0)
`feat: redid everything BREAKING CHANGE: everything is different` major version bump (1.2.3 -> 2.0.0)

 IMO, this works best if PRs are merged using squash and merge in Github, with the semantic release prefix added to the squash commit.

**NOTE**
This requires setting up a trusted publisher for `sae-vis` in PyPI. This likely needs to be done by @callummcdougall. This setting can be found under "publishing" in the PyPI management console for `sae-vis`. The settings should look like the following:

<img width="482" alt="Screenshot 2024-04-21 at 01 01 41" src="https://github.com/callummcdougall/sae_vis/assets/200725/e2215318-9c7a-4508-b721-b0d7eb097cb6">

 closes #37