### PR TITLE
config to remove pre-encoder bias

### DIFF
--- a/sae_vis/data_fetching_fns.py
+++ b/sae_vis/data_fetching_fns.py
@@ -85,7 +85,7 @@ def compute_feat_acts(
     feature_bias = encoder.b_enc[feature_idx]  # (feats,)
 
     # Calculate & store feature activations (we need to store them so we can get the sequence & histogram vis later)
-    x_cent = model_acts - encoder.b_dec
+    x_cent = model_acts -  encoder.b_dec * encoder.cfg.apply_b_dec_to_input
     feat_acts_pre = einops.einsum(
         x_cent, feature_act_dir, "batch seq d_in, d_in feats -> batch seq feats"
     )
@@ -110,7 +110,7 @@ def compute_feat_acts(
         assert (
             encoder_B is not None
         ), "Error: you need to supply an encoder-B object if you want to calculate encoder-B feature activations."
-        x_cent_B = model_acts - encoder_B.b_dec
+        x_cent_B = model_acts - encoder_B.b_dec * encoder_B.cfg.apply_b_dec_to_input
         feat_acts_pre_B = einops.einsum(
             x_cent_B,
             encoder_B.W_enc,

--- a/sae_vis/model_fns.py
+++ b/sae_vis/model_fns.py
@@ -51,6 +51,8 @@ class AutoEncoderConfig:
 
     l1_coeff: float = 3e-4
 
+    apply_b_dec_to_input: bool = True
+
     def __post_init__(self):
         assert (
             int(self.d_hidden is None) + int(self.dict_mult is None) == 1
@@ -81,7 +83,7 @@ class AutoEncoder(nn.Module):
         self.W_dec.data[:] = self.W_dec / self.W_dec.norm(dim=-1, keepdim=True)
 
     def forward(self, x: torch.Tensor):
-        x_cent = x - self.b_dec
+        x_cent = x - self.b_dec * self.cfg.apply_b_dec_to_input
         acts = F.relu(x_cent @ self.W_enc + self.b_enc)
         x_reconstruct = acts @ self.W_dec + self.b_dec
         l2_loss = (x_reconstruct.float() - x.float()).pow(2).sum(-1).mean(0)


### PR DESCRIPTION
Following SAELens, AutoEncoder config is given a boolean `apply_b_dec_to_input`, that decides whether decoder bias should be subtracted from the input.

When loading a model trained with SAELens, this variable is read from the SAELens model config. The default value is set to True. 

I have checked that the code passes all the tests with `make check-all`.