### PR TITLE
Add check for valid feature_idx in save_feature_centric_vis

### DIFF
--- a/sae_vis/data_storing_fns.py
+++ b/sae_vis/data_storing_fns.py
@@ -1065,6 +1065,7 @@ class SaeVisData:
         HTML_OBJ = HTML()
 
         # Set the default argument for the dropdown (i.e. when the page first loads)
+        assert feature_idx is None or feature_idx in self.feature_data_dict, "Specified feature_idx not in specified features"
         first_feature = (
             next(iter(self.feature_data_dict)) if (feature_idx is None) else feature_idx
         )


### PR DESCRIPTION
Added an assert which ensures that the `feature_idx` specified a user is present in the `feature_data_dict`. If this is not the case then the html will still be produced but will not contain divs for the other features, which made the source of the error a bit tricky to track down.