### PR TITLE
chore: fixing typing errors for pyright 1.1.373

### DIFF
--- a/sae_vis/data_storing_fns.py
+++ b/sae_vis/data_storing_fns.py
@@ -534,11 +534,14 @@ class SequenceData:
                         uColor=uColorMap(u_values[i]),
                     )
 
+            # pyright 1.1.373 freaks out if rounding is done in-line below for some reason
+            # this is likely a bug in 1.1.373, but rounding here is equivalent anyway
+            token_logit = round(self.token_logits[i], PRECISION)
             js_data_list.append(
                 dict(
                     tok=unprocess_str_tok(toks[i]),
                     tokID=self.token_ids[i],
-                    tokenLogit=round(self.token_logits[i], PRECISION),
+                    tokenLogit=token_logit,
                     **kwargs_bold,
                     **kwargs_this_token_active,
                     **kwargs_prev_token_active,

--- a/sae_vis/utils_fns.py
+++ b/sae_vis/utils_fns.py
@@ -8,7 +8,6 @@ from typing import (
     Iterable,
     Literal,
     Sequence,
-    Type,
     TypeVar,
     overload,
 )
@@ -1030,12 +1029,12 @@ class HistogramData:
 
     @classmethod
     def from_data(
-        cls: Type[T],
+        cls,
         data: Tensor,
         n_bins: int,
         tickmode: Literal["ints", "5 ticks"],
         title: str | None,
-    ) -> T:
+    ):
         """
         Args:
             data: 1D tensor of data which will be turned into histogram
@@ -1084,7 +1083,7 @@ class HistogramData:
             )
             tick_vals = [round(t, 1) for t in tick_vals]
 
-        return cls(  # type: ignore
+        return cls(
             bar_heights=bar_heights,
             bar_values=bar_values,
             tick_vals=tick_vals,


### PR DESCRIPTION
This PR fixes typing issues with the most recent merge, which seems to be related to the newest version of pyright. The `cls` errors begin appearing in 1.1.372, and the error about the `round()` function is only in 1.1.373. I think the 1.1.373 issue is a bug in pyright, because it doesn't make any sense why this should be an error, and the error disappears if the `round()` is moved one line up. Also `round()` is called lots of other places in the file with similar arguments with no issues. Moving the line up doesn't change the logic at all and fixes typing, so... 🤷‍♂️.